### PR TITLE
sprint12_04_a44371_repo_pull

### DIFF
--- a/cookbooks/repo/attributes/repo.rb
+++ b/cookbooks/repo/attributes/repo.rb
@@ -21,9 +21,4 @@ set_unless[:repo][:default][:environment]= ({})
 set_unless[:repo][:default][:symlinks]= ({})
 set_unless[:repo][:default][:purge_before_symlink] = %w{}
 set_unless[:repo][:default][:create_dirs_before_symlink] = %w{}
-
-if set_unless[:repo][:default][:perform_action] == "pull"
-  set_unless[:repo][:default][:perform_action] = :pull
-else
-  set_unless[:repo][:default][:perform_action] = :capistrano_pull
-end
+set_unless[:repo][:default][:perform_action] = :pull

--- a/cookbooks/repo/metadata.json
+++ b/cookbooks/repo/metadata.json
@@ -1,213 +1,222 @@
 {
-  "dependencies": {
-    "repo_ros": ">= 0.0.0",
-    "repo_git": ">= 0.0.0",
-    "rightscale": ">= 0.0.0",
-    "repo_svn": ">= 0.0.0"
-  },
-  "name": "repo",
-  "maintainer_email": "support@rightscale.com",
-  "attributes": {
-    "repo/default/storage_account_provider": {
-      "required": "optional",
-      "calculated": false,
-      "choice": [
-        "S3",
-        "CloudFiles"
-      ],
-      "type": "string",
-      "recipes": [
-        "repo::default"
-      ],
-      "display_name": "ROS Storage Account Provider",
-      "description": "Location where the source file is saved. Used by recipes to upload to Amazon S3 or Rackspace Cloud Files."
-    },
-    "repo/default/repository": {
-      "required": "recommended",
-      "calculated": false,
-      "choice": [
-
-      ],
-      "type": "string",
-      "recipes": [
-        "repo::default"
-      ],
-      "display_name": "Repository Url",
-      "description": "The URL of your svn or git repository where your application code will be checked out. Ex: http://mysvn.net/app/ or git@github.com/whoami/project"
-    },
-    "repo/default/perform_action": {
-      "required": "recommended",
-      "calculated": false,
-      "choice": [
-        "pull",
-        "capistrano_pull"
-      ],
-      "type": "string",
-      "recipes": [
-        "repo::do_pull"
-      ],
-      "display_name": "Action",
-      "description": "Choose the pull action which will be performed, 'pull'- standard repo pull, 'capistrano_pull' standard pull and then capistrano deployment style will be applied."
-    },
-    "repo/default/container": {
-      "required": "optional",
-      "calculated": false,
-      "choice": [
-
-      ],
-      "type": "string",
-      "recipes": [
-        "repo::default"
-      ],
-      "display_name": "ROS Container",
-      "description": "The cloud storage location where the dump file will be saved to or restored from. For Amazon S3, use the bucket name. For Rackspace Cloud Files, use the container name."
-    },
-    "repo/default/svn_password": {
-      "required": "optional",
-      "calculated": false,
-      "choice": [
-
-      ],
-      "default": "",
-      "type": "string",
-      "recipes": [
-        "repo::default"
-      ],
-      "display_name": "SVN password",
-      "description": "Password for SVN repository."
-    },
-    "repo/default/destination": {
-      "required": "recommended",
-      "calculated": false,
-      "choice": [
-
-      ],
-      "type": "string",
-      "recipes": [
-        "repo::do_pull"
-      ],
-      "display_name": "Project App root",
-      "description": "Path to where project repo will be pulled"
-    },
-    "repo/default/prefix": {
-      "required": "optional",
-      "calculated": false,
-      "choice": [
-
-      ],
-      "type": "string",
-      "recipes": [
-        "repo::default"
-      ],
-      "display_name": "ROS Prefix",
-      "description": "The prefix that will be used to name/locate the backup of a particular source repository. Defines the prefix of the source repo file name that will be used to name the downloaded repository file."
-    },
-    "repo/default/ssh_key": {
-      "required": "recommended",
-      "calculated": false,
-      "choice": [
-
-      ],
-      "default": "",
-      "type": "string",
-      "recipes": [
-        "repo::default"
-      ],
-      "display_name": "SSH Key",
-      "description": "The private SSH key of the git repository."
-    },
-    "repo/default/storage_account_secret": {
-      "required": "optional",
-      "calculated": false,
-      "choice": [
-
-      ],
-      "type": "string",
-      "recipes": [
-        "repo::default"
-      ],
-      "display_name": "ROS Storage Account Secret",
-      "description": "In order to write the dump file to the specified cloud storage location, you will need to provide cloud authentication credentials. For Amazon S3, use your AWS secret access key (e.g., cred:AWS_SECRET_ACCESS_KEY). For Rackspace Cloud Files, use your Rackspace account API key (e.g., cred:RACKSPACE_AUTH_KEY)."
-    },
-    "repo/default/storage_account_id": {
-      "required": "optional",
-      "calculated": false,
-      "choice": [
-
-      ],
-      "type": "string",
-      "recipes": [
-        "repo::default"
-      ],
-      "display_name": "ROS Storage Account ID",
-      "description": "In order to write the repository to the specified cloud storage location, you need to provide cloud authentication credentials. For Amazon S3, use your Amazon access key ID (e.g., cred:AWS_ACCESS_KEY_ID). For Rackspace Cloud Files, use your Rackspace login username (e.g., cred:RACKSPACE_USERNAME)."
-    },
-    "repo/default/revision": {
-      "required": "recommended",
-      "calculated": false,
-      "choice": [
-
-      ],
-      "default": "master",
-      "type": "string",
-      "recipes": [
-        "repo::default"
-      ],
-      "display_name": "Branch/Tag",
-      "description": "Enter the branch of your repository you want to fetch. Default: master"
-    },
-    "repo/default/provider": {
-      "required": "recommended",
-      "calculated": false,
-      "choice": [
-        "repo_git",
-        "repo_svn",
-        "repo_ros"
-      ],
-      "default": "repo_git",
-      "type": "string",
-      "recipes": [
-        "repo::default"
-      ],
-      "display_name": "Repository Provider",
-      "description": "Select a repository provider: repo_git for Git, repo_svn for SVN or repo_ros for Remote Ojbect Store. Default: repo_git"
-    },
-    "repo/default/svn_username": {
-      "required": "optional",
-      "calculated": false,
-      "choice": [
-
-      ],
-      "default": "",
-      "type": "string",
-      "recipes": [
-        "repo::default"
-      ],
-      "display_name": "SVN username",
-      "description": "Username for SVN repository."
-    }
-  },
-  "license": "Copyright RightScale, Inc. All rights reserved.",
+  "maintainer": "RightScale, Inc.",
   "suggestions": {
+  },
+  "maintainer_email": "support@rightscale.com",
+  "long_description": "= RightScale Repo Resource\n\n== DESCRIPTION:\n\nThis cookbook provides abstract 'repo' resource for managing code download from GIT, SVN or ROS code repositories.\n\n\n== DETAILS:\n\n=== General\nThis cookbook is intended to be used in conjunction with cookbooks that contain\nLightweight Providers which implement the 'repo' interface. See the RightScale\nrepo_git cookbook for an example.\n\nFor more about Lightweight Resources and Providers (LWRPs), please see the Chef\nwiki at: http://wiki.opscode.com/display/chef/Lightweight+Resources+and+Providers+%28LWRP%29\n  \n== REQUIREMENTS:\n\n*  One of 'repo' provider: 'repo_git', 'repo_svn' or 'repo_ros' cookbooks must be present in your cookbook repository\n*  Ros implementation depends on the 'rightscale::install_tools' recipe\n\n\n== SETUP:\n\n* Place repo::default recipe into your runlist to setup the repo resource.  When\n  using a RightScale ServerTemplate, this will also automatically add the\n  required attributes to your ServerTemplate inputs.\n\n\n== USAGE:\n\n=== General\n* Add 'repo' resource call in your recipe and provide all required parameters.\n* Add 'destination' and 'action' attributes to your 'repo' resource.\n\n* Set desired action for your 'repo' resource\n  It can be :pull or :capistrano_pull\n  :pull - perform basic 'repo' action, just pulling your code from remote repo.\n  :capistrano_pull - performs pulling and backup of yuor code, see: http://wiki.opscode.com/display/chef/Deploy+Resource#DeployResource-TheDeployStrategies\n\n=== Examples\n\n:pull Example:\n\nrepo 'default' do\n  destination '/tmp/repo'\n  action :pull\nend\n\n:capistrano_pull Example:\n\nrepo 'default' do\n  destination '/tmp/repo'\n  action :capistrano_pull\n  app_user                    'rightscale' #owner of created repo directories\n  purge_before_symlink        %w{tmp} #An array of paths, relative to app root, to be removed from a checkout before symlinking\n  create_dirs_before_symlink  %w{log dir2}  #A hash that maps files in the shared directory to their paths in the current release\n  symlinks                    ({}) #A hash that maps files in the shared directory to their paths in the current release\n  environment                 ({}) #A hash of the form {'ENV_VARIABLE'=>'VALUE'}\nend\n\n=== SVN options:\n  svn_username                Svn username\n  svn_password                Svn password\n\n=== ROS options:\n  storage_account_provider    S3 or Cloudfiles currently supported\n  storage_account_id          'Amazon account id' #For Amazon S3, use your Amazon access key ID (e.g., cred:AWS_ACCESS_KEY_ID). For Rackspace Cloud Files, use your Rackspace login username (e.g., cred:RACKSPACE_USERNAME).\n  storage_account_secret      'Amazon account password' # For Amazon S3, use your AWS secret access key (e.g., cred:AWS_SECRET_ACCESS_KEY). For Rackspace Cloud Files, use your Rackspace account API key (e.g., cred:RACKSPACE_AUTH_KEY).\n  container                   'Your_bucket' #For Amazon S3, use the bucket name. For Rackspace Cloud Files, use the container name.\n  prefix                      'source.tar.gz' #Defines the prefix of the source repo file name that will be used to name the downloaded repo file.\n\n\n= LICENSE\n\nCopyright RightScale, Inc. All rights reserved.  All access and use subject to the\nRightScale Terms of Service available at http://www.rightscale.com/terms.php and,\nif applicable, other agreements such as a RightScale Master Subscription Agreement.\n",
+  "description": "Abstract cookbook for managing source code repositories.",
+  "conflicting": {
   },
   "platforms": {
   },
-  "maintainer": "RightScale, Inc.",
-  "long_description": "= RightScale Repo Resource\n\n== DESCRIPTION:\n\nThis cookbook provides abstract 'repo' resource for managing code download from GIT, SVN or ROS code repositories.\n\n\n== DETAILS:\n\n=== General\nThis cookbook is intended to be used in conjunction with cookbooks that contain\nLightweight Providers which implement the 'repo' interface. See the RightScale\nrepo_git cookbook for an example.\n\nFor more about Lightweight Resources and Providers (LWRPs), please see the Chef\nwiki at: http://wiki.opscode.com/display/chef/Lightweight+Resources+and+Providers+%28LWRP%29\n  \n== REQUIREMENTS:\n\n*  One of 'repo' provider: 'repo_git', 'repo_svn' or 'repo_ros' cookbooks must be present in your cookbook repository\n*  Ros implementation depends on the 'rightscale::install_tools' recipe\n\n\n== SETUP:\n\n* Place repo::default recipe into your runlist to setup the repo resource.  When\n  using a RightScale ServerTemplate, this will also automatically add the\n  required attributes to your ServerTemplate inputs.\n\n\n== USAGE:\n\n=== General\n* Add 'repo' resource call in your recipe and provide all required parameters.\n* Add 'destination' and 'action' attributes to your 'repo' resource.\n\n* Set desired action for your 'repo' resource\n  It can be :pull or :capistrano_pull\n  :pull - perform basic 'repo' action, just pulling your code from remote repo.\n  :capistrano_pull - performs pulling and backup of yuor code, see: http://wiki.opscode.com/display/chef/Deploy+Resource#DeployResource-TheDeployStrategies\n\n=== Examples\n\n:pull Example:\n\nrepo 'default' do\n  destination '/tmp/repo'\n  action :pull\nend\n\n:capistrano_pull Example:\n\nrepo 'default' do\n  destination '/tmp/repo'\n  action :capistrano_pull\n  app_user                    'rightscale' #owner of created repo directories\n  purge_before_symlink        %w{tmp} #An array of paths, relative to app root, to be removed from a checkout before symlinking\n  create_dirs_before_symlink  %w{log dir2}  #A hash that maps files in the shared directory to their paths in the current release\n  symlinks                    ({}) #A hash that maps files in the shared directory to their paths in the current release\n  environment                 ({}) #A hash of the form {'ENV_VARIABLE'=>'VALUE'}\nend\n\n=== SVN options:\n  svn_username                Svn username\n  svn_password                Svn password\n\n=== ROS options:\n  storage_account_provider    S3 or Cloudfiles currently supported\n  storage_account_id          'Amazon account id' #For Amazon S3, use your Amazon access key ID (e.g., cred:AWS_ACCESS_KEY_ID). For Rackspace Cloud Files, use your Rackspace login username (e.g., cred:RACKSPACE_USERNAME).\n  storage_account_secret      'Amazon account password' # For Amazon S3, use your AWS secret access key (e.g., cred:AWS_SECRET_ACCESS_KEY). For Rackspace Cloud Files, use your Rackspace account API key (e.g., cred:RACKSPACE_AUTH_KEY).\n  container                   'Your_bucket' #For Amazon S3, use the bucket name. For Rackspace Cloud Files, use the container name.\n  prefix                      'source.tar.gz' #Defines the prefix of the source repo file name that will be used to name the downloaded repo file.\n\n\n= LICENSE\n\nCopyright RightScale, Inc. All rights reserved.  All access and use subject to the\nRightScale Terms of Service available at http://www.rightscale.com/terms.php and,\nif applicable, other agreements such as a RightScale Master Subscription Agreement.\n",
-  "version": "0.0.1",
-  "recommendations": {
+  "license": "Copyright RightScale, Inc. All rights reserved.",
+  "providing": {
   },
   "recipes": {
     "repo::do_pull": "Recipe for pulling project repos from svn, git or ros.",
     "repo::default": "Default recipe for setup resources provided"
   },
-  "groupings": {
-  },
-  "conflicting": {
+  "attributes": {
+    "repo/default/destination": {
+      "choice": [
+
+      ],
+      "display_name": "Project App root",
+      "recipes": [
+        "repo::default"
+      ],
+      "description": "Destination location path for project repo",
+      "calculated": false,
+      "required": "recommended",
+      "type": "string"
+    },
+    "repo/default/container": {
+      "choice": [
+
+      ],
+      "display_name": "ROS Container",
+      "recipes": [
+        "repo::default"
+      ],
+      "description": "The cloud storage location where the dump file will be saved to or restored from. For Amazon S3, use the bucket name. For Rackspace Cloud Files, use the container name.",
+      "calculated": false,
+      "required": "optional",
+      "type": "string"
+    },
+    "repo/default/storage_account_provider": {
+      "choice": [
+        "S3",
+        "CloudFiles"
+      ],
+      "display_name": "ROS Storage Account Provider",
+      "recipes": [
+        "repo::default"
+      ],
+      "description": "Location where the source file is saved. Used to pull source from Remote Object Stores.",
+      "calculated": false,
+      "required": "optional",
+      "type": "string"
+    },
+    "repo/default/svn_password": {
+      "choice": [
+
+      ],
+      "display_name": "SVN password",
+      "recipes": [
+        "repo::default"
+      ],
+      "description": "Password for SVN repository.",
+      "calculated": false,
+      "required": "optional",
+      "type": "string",
+      "default": ""
+    },
+    "repo/default/git_ssh_key": {
+      "choice": [
+
+      ],
+      "display_name": "Git SSH Key",
+      "recipes": [
+        "repo::default"
+      ],
+      "description": "The private SSH key of the git repository.",
+      "calculated": false,
+      "required": "recommended",
+      "type": "string",
+      "default": ""
+    },
+    "repo/default/provider": {
+      "choice": [
+        "repo_git",
+        "repo_svn",
+        "repo_ros"
+      ],
+      "display_name": "Repository Provider",
+      "recipes": [
+        "repo::default"
+      ],
+      "description": "Select a repository provider: repo_git for Git, repo_svn for SVN or repo_ros for Remote Ojbect Store. Default: repo_git",
+      "calculated": false,
+      "required": "recommended",
+      "type": "string",
+      "default": "repo_git"
+    },
+    "repo/default/perform_action": {
+      "choice": [
+        "pull",
+        "capistrano_pull"
+      ],
+      "display_name": "Action",
+      "recipes": [
+        "repo::default"
+      ],
+      "description": "Choose the pull action which will be performed, 'pull'- standard repo pull, 'capistrano_pull' standard pull and then capistrano deployment style will be applied.",
+      "calculated": false,
+      "required": "optional",
+      "type": "string",
+      "default": "pull"
+    },
+    "repo/default/storage_account_secret": {
+      "choice": [
+
+      ],
+      "display_name": "ROS Storage Account Secret",
+      "recipes": [
+        "repo::default"
+      ],
+      "description": "In order to write the dump file to the specified cloud storage location, you will need to provide cloud authentication credentials. For Amazon S3, use your AWS secret access key (e.g., cred:AWS_SECRET_ACCESS_KEY). For Rackspace Cloud Files, use your Rackspace account API key (e.g., cred:RACKSPACE_AUTH_KEY).",
+      "calculated": false,
+      "required": "optional",
+      "type": "string"
+    },
+    "repo/default/svn_username": {
+      "choice": [
+
+      ],
+      "display_name": "SVN username",
+      "recipes": [
+        "repo::default"
+      ],
+      "description": "Username for SVN repository.",
+      "calculated": false,
+      "required": "optional",
+      "type": "string",
+      "default": ""
+    },
+    "repo/default/repository": {
+      "choice": [
+
+      ],
+      "display_name": "Repository Url",
+      "recipes": [
+        "repo::default"
+      ],
+      "description": "The URL of your svn or git repository where your application code will be checked out. Ex: http://mysvn.net/app/ or git@github.com/whoami/project",
+      "calculated": false,
+      "required": "recommended",
+      "type": "string"
+    },
+    "repo/default/storage_account_id": {
+      "choice": [
+
+      ],
+      "display_name": "ROS Storage Account ID",
+      "recipes": [
+        "repo::default"
+      ],
+      "description": "In order to write the repository to the specified cloud storage location, you need to provide cloud authentication credentials. For Amazon S3, use your Amazon access key ID (e.g., cred:AWS_ACCESS_KEY_ID). For Rackspace Cloud Files, use your Rackspace login username (e.g., cred:RACKSPACE_USERNAME).",
+      "calculated": false,
+      "required": "optional",
+      "type": "string"
+    },
+    "repo/default/revision": {
+      "choice": [
+
+      ],
+      "display_name": "Branch/Tag",
+      "recipes": [
+        "repo::default"
+      ],
+      "description": "Enter the branch of your repository you want to fetch. Default: master",
+      "calculated": false,
+      "required": "recommended",
+      "type": "string",
+      "default": "master"
+    },
+    "repo/default/prefix": {
+      "choice": [
+
+      ],
+      "display_name": "ROS Prefix",
+      "recipes": [
+        "repo::default"
+      ],
+      "description": "The prefix that will be used to name/locate the backup of a particular source repository. Defines the prefix of the source repo file name that will be used to name the downloaded repository file.",
+      "calculated": false,
+      "required": "optional",
+      "type": "string"
+    }
   },
   "replacing": {
   },
-  "description": "Abstract cookbook for managing source code repositories.",
-  "providing": {
+  "dependencies": {
+    "repo_git": [
+
+    ],
+    "rightscale": [
+
+    ],
+    "repo_ros": [
+
+    ],
+    "repo_svn": [
+
+    ]
+  },
+  "name": "repo",
+  "groupings": {
+  },
+  "version": "0.0.1",
+  "recommendations": {
   }
 }

--- a/cookbooks/repo/metadata.rb
+++ b/cookbooks/repo/metadata.rb
@@ -35,7 +35,7 @@ attribute "repo/default/revision",
   :default => "master",
   :recipes => ["repo::default"]
 
-#SVN
+# SVN
 attribute "repo/default/svn_username",
   :display_name => "SVN username",
   :description => "Username for SVN repository.",
@@ -50,18 +50,18 @@ attribute "repo/default/svn_password",
   :default => "",
   :recipes => ["repo::default"]
 
-#GIT
-attribute "repo/default/ssh_key",
-  :display_name => "SSH Key",
+# GIT
+attribute "repo/default/git_ssh_key",
+  :display_name => "Git SSH Key",
   :description => "The private SSH key of the git repository.",
   :default => "",
   :required => "recommended",
   :recipes => ["repo::default"]
 
-#ROS
+# ROS
 attribute "repo/default/storage_account_provider",
   :display_name => "ROS Storage Account Provider",
-  :description => "Location where the source file is saved. Used by recipes to upload to Amazon S3 or Rackspace Cloud Files.",
+  :description => "Location where the source file is saved. Used to pull source from Remote Object Stores.",
   :required => "optional",
   :choice => [ "S3", "CloudFiles" ],
   :recipes => ["repo::default"]
@@ -90,19 +90,16 @@ attribute "repo/default/prefix",
   :required => "optional",
   :recipes => ["repo::default"]
 
-#capistrano attributes used in repo::do_pull
-
 attribute "repo/default/perform_action",
   :display_name => "Action",
   :description => "Choose the pull action which will be performed, 'pull'- standard repo pull, 'capistrano_pull' standard pull and then capistrano deployment style will be applied.",
   :choice => [ "pull", "capistrano_pull" ],
-  :required => "recommended",
-  :recipes => ["repo::do_pull"]
-
+  :default => "pull",
+  :required => "optional",
+  :recipes => ["repo::default"]
 
 attribute "repo/default/destination",
   :display_name => "Project App root",
-  :description => "Path to where project repo will be pulled",
+  :description => "Destination location path for project repo",
   :required => "recommended",
-  :recipes => ["repo::do_pull"]
-
+  :recipes => ["repo::default"]

--- a/cookbooks/repo/recipes/do_pull.rb
+++ b/cookbooks/repo/recipes/do_pull.rb
@@ -14,8 +14,8 @@ if ( node[:repo][:default][:destination]== "") then
 end
 
 repo "default" do
-  destination                 node[:repo][:default][:destination]
-  action                      node[:repo][:default][:perform_action]
+  destination node[:repo][:default][:destination]
+  action      node[:repo][:default][:perform_action].to_sym
 end
 
 rightscale_marker :end

--- a/cookbooks/repo_git/libraries/helper.rb
+++ b/cookbooks/repo_git/libraries/helper.rb
@@ -11,11 +11,11 @@ module RightScale
      KEYFILE = "/tmp/gitkey"
 
      # Add ssh key and exec script
-     def create(ssh_key)
+     def create(git_ssh_key)
        Chef::Log.info("Creating ssh key")
 
        keyfile = nil
-       keyname = ssh_key
+       keyname = git_ssh_key
        if "#{keyname}" != ""
          keyfile = KEYFILE
          system("echo -n '#{keyname}' > #{keyfile}")

--- a/cookbooks/repo_git/providers/default.rb
+++ b/cookbooks/repo_git/providers/default.rb
@@ -16,7 +16,7 @@ action :pull do
         ::File.rename("#{new_resource.destination}", "#{capistrano_dir}/releases/capistrano_old_"+::Time.now.strftime("%Y%m%d%H%M"))
       end
       # add ssh key and exec script
-      RightScale::Repo::Ssh_key.new.create(new_resource.ssh_key)
+      RightScale::Repo::Ssh_key.new.create(new_resource.git_ssh_key)
     end
   end
 
@@ -61,7 +61,7 @@ action :capistrano_pull do
 
   ruby_block "Before deploy" do
     block do
-       RightScale::Repo::Ssh_key.new.create(new_resource.ssh_key)
+       RightScale::Repo::Ssh_key.new.create(new_resource.git_ssh_key)
     end
   end
 

--- a/cookbooks/repo_svn/providers/default.rb
+++ b/cookbooks/repo_svn/providers/default.rb
@@ -35,7 +35,7 @@ action :pull do
     end
   end
 
-  Log "  ROS repo pull action - finished successfully!"
+  Log "  SVN repo pull action - finished successfully!"
 end
 
 action :capistrano_pull do


### PR DESCRIPTION
[repo] attributes - perform_action default to :pull
[repo] metadata - assign repo/default/perform_action and repo/default/destination input to repo::default.
[repo::do_pull] - assure that action passed is a symbol
[repo_git] helper - variable name consitency as made in [repo] metadata, git_ssh_key
[repo_git::default] - variable name consitency as made in [repo] metadata, git_ssh_key
[repo_svn::default] - correct log message
