### PR TITLE
Sprint12 04 a45981 lineage timestamp fix

### DIFF
--- a/cookbooks/block_device/recipes/do_primary_restore.rb
+++ b/cookbooks/block_device/recipes/do_primary_restore.rb
@@ -22,10 +22,10 @@ do_for_block_devices node[:block_device] do |device|
   lineage_override = get_device_or_default(node, device, :backup, :lineage_override)
   restore_lineage = lineage_override == nil || lineage_override.empty? ? lineage : lineage_override
   restore_timestamp_override = get_device_or_default(node, device, :backup, :timestamp_override)
-  log "  Input lineage #{restore_lineage}"
-  log "  Input lineage_override #{lineage_override}"
-  log "  Using lineage #{restore_lineage}"
-  log "  Input timestamp_override #{restore_timestamp_override}"
+  log "  Input lineage #{restore_lineage.inspect}"
+  log "  Input lineage_override #{lineage_override.inspect}"
+  log "  Using lineage #{restore_lineage.inspect}"
+  log "  Input timestamp_override #{restore_timestamp_override.inspect}"
 
   block_device get_device_or_default(node, device, :nickname) do
     # Backup/Restore arguments

--- a/cookbooks/block_device/recipes/do_primary_restore.rb
+++ b/cookbooks/block_device/recipes/do_primary_restore.rb
@@ -21,16 +21,16 @@ do_for_block_devices node[:block_device] do |device|
   lineage = get_device_or_default(node, device, :backup, :lineage)
   lineage_override = get_device_or_default(node, device, :backup, :lineage_override)
   restore_lineage = lineage_override == nil || lineage_override.empty? ? lineage : lineage_override
-  timestamp_override = get_device_or_default(node, device, :backup, :timestamp_override)
+  restore_timestamp_override = get_device_or_default(node, device, :backup, :timestamp_override)
   log "  Input lineage #{restore_lineage}"
   log "  Input lineage_override #{lineage_override}"
   log "  Using lineage #{restore_lineage}"
-  log "  Input timestamp_override #{timestamp_override}"
+  log "  Input timestamp_override #{restore_timestamp_override}"
 
   block_device get_device_or_default(node, device, :nickname) do
     # Backup/Restore arguments
     lineage restore_lineage
-    timestamp_override timestamp_override
+    timestamp_override restore_timestamp_override
 
     action :primary_restore
   end

--- a/cookbooks/block_device/recipes/do_primary_restore.rb
+++ b/cookbooks/block_device/recipes/do_primary_restore.rb
@@ -26,6 +26,7 @@ do_for_block_devices node[:block_device] do |device|
   log "  Input lineage_override #{lineage_override.inspect}"
   log "  Using lineage #{restore_lineage.inspect}"
   log "  Input timestamp_override #{restore_timestamp_override.inspect}"
+  restore_timestamp_override ||= ""
 
   block_device get_device_or_default(node, device, :nickname) do
     # Backup/Restore arguments

--- a/cookbooks/block_device/recipes/do_secondary_restore.rb
+++ b/cookbooks/block_device/recipes/do_secondary_restore.rb
@@ -22,10 +22,10 @@ do_for_block_devices node[:block_device] do |device|
   lineage_override = get_device_or_default(node, device, :backup, :lineage_override)
   restore_lineage = lineage_override == nil || lineage_override.empty? ? lineage : lineage_override
   restore_timestamp_override = get_device_or_default(node, device, :backup, :timestamp_override)
-  log "  Input lineage #{restore_lineage}"
-  log "  Input lineage_override #{lineage_override}"
-  log "  Using lineage #{restore_lineage}"
-  log "  Input timestamp_override #{restore_timestamp_override}"
+  log "  Input lineage #{restore_lineage.inspect}"
+  log "  Input lineage_override #{lineage_override.inspect}"
+  log "  Using lineage #{restore_lineage.inspect}"
+  log "  Input timestamp_override #{restore_timestamp_override.inspect}"
 
   block_device get_device_or_default(node, device, :nickname) do
     # Backup/Restore arguments

--- a/cookbooks/block_device/recipes/do_secondary_restore.rb
+++ b/cookbooks/block_device/recipes/do_secondary_restore.rb
@@ -26,6 +26,7 @@ do_for_block_devices node[:block_device] do |device|
   log "  Input lineage_override #{lineage_override.inspect}"
   log "  Using lineage #{restore_lineage.inspect}"
   log "  Input timestamp_override #{restore_timestamp_override.inspect}"
+  restore_timestamp_override ||= ""
 
   block_device get_device_or_default(node, device, :nickname) do
     # Backup/Restore arguments

--- a/cookbooks/block_device/recipes/do_secondary_restore.rb
+++ b/cookbooks/block_device/recipes/do_secondary_restore.rb
@@ -21,14 +21,16 @@ do_for_block_devices node[:block_device] do |device|
   lineage = get_device_or_default(node, device, :backup, :lineage)
   lineage_override = get_device_or_default(node, device, :backup, :lineage_override)
   restore_lineage = lineage_override == nil || lineage_override.empty? ? lineage : lineage_override
+  restore_timestamp_override = get_device_or_default(node, device, :backup, :timestamp_override)
   log "  Input lineage #{restore_lineage}"
   log "  Input lineage_override #{lineage_override}"
   log "  Using lineage #{restore_lineage}"
+  log "  Input timestamp_override #{restore_timestamp_override}"
 
   block_device get_device_or_default(node, device, :nickname) do
     # Backup/Restore arguments
     lineage restore_lineage
-    timestamp_override get_device_or_default(node, device, :backup, :timestamp_override)
+    timestamp_override restore_timestamp_override
 
     secondary_cloud get_device_or_default(node, device, :backup, :secondary, :cloud)
     secondary_endpoint get_device_or_default(node, device, :backup, :secondary, :endpoint)


### PR DESCRIPTION
This improves logging and fixes timestamp override when the input has changed from something to blank. (w4617).
