### PR TITLE
Sprint12 05 a46724 reduce ntp logging verbosity

### DIFF
--- a/cookbooks/sys_ntp/templates/default/ntp.conf.erb
+++ b/cookbooks/sys_ntp/templates/default/ntp.conf.erb
@@ -13,7 +13,7 @@ tinker panic 0 dispersion 1.000
 
 driftfile /var/lib/ntp/ntp.drift
 statsdir /var/log/ntpstats/
-logconfig =syncall
+logconfig =syncstatus -syncall
 
 statistics loopstats peerstats clockstats
 filegen loopstats file loopstats type day enable

--- a/cookbooks/sys_ntp/templates/default/ntp.conf.erb
+++ b/cookbooks/sys_ntp/templates/default/ntp.conf.erb
@@ -13,6 +13,7 @@ tinker panic 0 dispersion 1.000
 
 driftfile /var/lib/ntp/ntp.drift
 statsdir /var/log/ntpstats/
+logconfig =syncall
 
 statistics loopstats peerstats clockstats
 filegen loopstats file loopstats type day enable


### PR DESCRIPTION
Changed the template ntp.conf.erb to include only major events in log. It
 was checked by running the server for few hours and by changing the time
 manually which wrote a single line in the /var/log/messages.
 {{{
 Jun  7 14:07:03 ip-10-36-10-212 ntpd[3831]: time reset -610.032977 s
 }}}
