### PR TITLE
Sprint12 05 a46725 block device logging unused inputs

### DIFF
--- a/cookbooks/block_device/recipes/default.rb
+++ b/cookbooks/block_device/recipes/default.rb
@@ -24,6 +24,8 @@ package "xfsprogs" do
   not_if { node[:platform] == "redhat" }
 end
 
+log "Inputs volume_size and stripe_count are not used in Rackspace cloud provider" only_if {node[:cloud][:provider] == 'rackspace'}
+
 bash "Load kernel modules" do
   flags '-ex'
   code <<-EOS

--- a/cookbooks/block_device/recipes/default.rb
+++ b/cookbooks/block_device/recipes/default.rb
@@ -24,7 +24,7 @@ package "xfsprogs" do
   not_if { node[:platform] == "redhat" }
 end
 
-log "Inputs volume_size and stripe_count are not used in Rackspace cloud provider" do
+log "Inputs volume_size and stripe_count are not used in Rackspace cloud provider. For further information, please visit this link: http://support.rightscale.com/09-Clouds/Rackspace_Hosting#Unsupported_Features" do
   only_if {node[:cloud][:provider] == 'rackspace'}
 end
 

--- a/cookbooks/block_device/recipes/default.rb
+++ b/cookbooks/block_device/recipes/default.rb
@@ -24,7 +24,7 @@ package "xfsprogs" do
   not_if { node[:platform] == "redhat" }
 end
 
-log "Inputs volume_size and stripe_count are not used in Rackspace cloud provider. For further information, please visit this link: http://support.rightscale.com/09-Clouds/Rackspace_Hosting#Unsupported_Features" do
+log "Inputs volume_size and stripe_count are not used in Rackspace cloud provider. For further information, please visit http://support.rightscale.com/09-Clouds/Rackspace_Hosting#Unsupported_Features" do
   only_if {node[:cloud][:provider] == 'rackspace'}
 end
 

--- a/cookbooks/block_device/recipes/default.rb
+++ b/cookbooks/block_device/recipes/default.rb
@@ -24,7 +24,9 @@ package "xfsprogs" do
   not_if { node[:platform] == "redhat" }
 end
 
-log "Inputs volume_size and stripe_count are not used in Rackspace cloud provider" only_if {node[:cloud][:provider] == 'rackspace'}
+log "Inputs volume_size and stripe_count are not used in Rackspace cloud provider" do
+  only_if {node[:cloud][:provider] == 'rackspace'}
+end
 
 bash "Load kernel modules" do
   flags '-ex'


### PR DESCRIPTION
Added in the log that 'volume_size and stripe_count are not used in Rackspace' for rackspace cloud provider. It has been tested with both Rackspace server and a non-Rackspace server.
