### PR TITLE
Sprint12 05 a46716 remote file deprecated bugfix

### DIFF
--- a/cookbooks/app_tomcat/providers/default.rb
+++ b/cookbooks/app_tomcat/providers/default.rb
@@ -73,7 +73,7 @@ action :install do
     end
   elsif db_adapter == "postgresql"
     # Copy to /usr/share/java/postgresql-9.1-901.jdbc4.jar
-    remote_file "/usr/share/java/postgresql-9.1-901.jdbc4.jar" do
+    cookbook_file "/usr/share/java/postgresql-9.1-901.jdbc4.jar" do
       source "postgresql-9.1-901.jdbc4.jar"
       owner "root"
       group "root"

--- a/cookbooks/block_device/recipes/setup_ephemeral.rb
+++ b/cookbooks/block_device/recipes/setup_ephemeral.rb
@@ -66,7 +66,7 @@ if cloud == 'ec2' || cloud == 'openstack'
     log "  Ephemeral entry already exists in fstab"
   else
     # Create init script to activate LVM on start for Ubuntu
-    remote_file "/etc/init.d/lvm_activate" do
+    cookbook_file "/etc/init.d/lvm_activate" do
       only_if { node[:platform] == "ubuntu" }
       source "lvm_activate"
       mode 0744

--- a/cookbooks/db_mysql/providers/default.rb
+++ b/cookbooks/db_mysql/providers/default.rb
@@ -314,14 +314,14 @@ action :install_server do
   # - set config file localhost access w/ root and no password
   # - disable the 'check_for_crashed_tables'.
   #
-  remote_file "/etc/mysql/debian.cnf" do
+  cookbook_file "/etc/mysql/debian.cnf" do
     only_if { platform == "ubuntu" }
     mode "0600"
     source "debian.cnf"
     cookbook 'db_mysql'
   end
 
-  remote_file "/etc/mysql/debian-start" do
+  cookbook_file "/etc/mysql/debian-start" do
     only_if { platform == "ubuntu" }
     mode "0755"
     source "debian-start"

--- a/cookbooks/lb_haproxy/providers/default.rb
+++ b/cookbooks/lb_haproxy/providers/default.rb
@@ -248,7 +248,7 @@ action :setup_monitoring do
   log "  Setup monitoring for haproxy"
 
   # Install the haproxy collectd script into the collectd library plugins directory.
-  remote_file(::File.join(node[:rightscale][:collectd_lib], "plugins", "haproxy")) do
+  cookbook_file(::File.join(node[:rightscale][:collectd_lib], "plugins", "haproxy")) do
     source "haproxy1.4.rb"
     cookbook "lb_haproxy"
     mode "0755"

--- a/cookbooks/rightscale/recipes/install_file_stats_collectd_plugin.rb
+++ b/cookbooks/rightscale/recipes/install_file_stats_collectd_plugin.rb
@@ -28,7 +28,7 @@ directory ::File.join(node[:rightscale][:collectd_lib], "plugins") do
   recursive true
 end
 
-remote_file(::File.join(node[:rightscale][:collectd_lib], "plugins", 'file-stats.rb')) do
+cookbook_file(::File.join(node[:rightscale][:collectd_lib], "plugins", 'file-stats.rb')) do
   source "file-stats.rb"
   mode "0755"
   notifies :restart, resources(:service => "collectd")

--- a/cookbooks/rightscale/recipes/install_mysql_collectd_plugin.rb
+++ b/cookbooks/rightscale/recipes/install_mysql_collectd_plugin.rb
@@ -18,7 +18,7 @@ package "collectd-mysql" do
   only_if { node[:platform] =~ /redhat|centos/ }
 end
 
-remote_file "#{node[:rightscale][:collectd_plugin_dir]}/mysql.conf" do
+cookbook_file "#{node[:rightscale][:collectd_plugin_dir]}/mysql.conf" do
   backup false
   source "collectd.mysql.conf"
   notifies :restart, resources(:service => "collectd")

--- a/cookbooks/rightscale/recipes/setup_monitoring.rb
+++ b/cookbooks/rightscale/recipes/setup_monitoring.rb
@@ -45,7 +45,7 @@ packages.each do |p|
 end
 
 # If APT, pin this package version so it can't be updated.
-remote_file "/etc/apt/preferences.d/00rightscale" do
+cookbook_file "/etc/apt/preferences.d/00rightscale" do
   only_if { node[:platform] == "ubuntu" }
   source "apt.preferences.rightscale"
 end
@@ -107,7 +107,7 @@ end
 # Patch collectd init script, so it uses collectdmon.
 # Only needed for CentOS, Ubuntu already does this out of the box.
 if node[:platform] =~ /redhat|centos/
-  remote_file "/etc/init.d/collectd" do
+  cookbook_file "/etc/init.d/collectd" do
     source "collectd-init-centos-with-monitor"
     mode 0755
     notifies :restart, resources(:service => "collectd")


### PR DESCRIPTION
## ...ious cookbooks to fix the bug of Remote_file being reprecated.

This fix has been tested with the "setup_monitoring" recipe of "rightscale" cookbook on "Chef based base linux" server template.
