### PR TITLE
Sprint12 05 a46709 document block device resource

### DIFF
--- a/cookbooks/block_device/resources/default.rb
+++ b/cookbooks/block_device/resources/default.rb
@@ -7,10 +7,22 @@
 
 require 'uri'
 
-actions :create, :snapshot, :primary_backup, :primary_restore, :secondary_backup, :secondary_restore, :reset, :backup_schedule_enable, :backup_schedule_disable, :backup_lock_take, :backup_lock_give
+# Add actions to @action_list array.
+# Used to allow comments between entries.
+def self.add_action(sym)
+  @action_list ||= Array.new
+  @action_list << sym unless @action_list.include?(sym)
+  @action_list
+end
 
+
+# = Block_device Attributes
+# 
+# Below are the attributes defined by the block_device resource interface.
+#
+
+# == General options
 attribute :nickname, :kind_of => String, :name_attribute => true
-
 attribute :cloud, :required => true
 attribute :hypervisor, :kind_of => String
 attribute :mount_point, :kind_of => String, :required => true
@@ -18,31 +30,32 @@ attribute :force, :kind_of => [TrueClass, FalseClass], :default => false
 attribute :is_master, :kind_of => [TrueClass, FalseClass], :default => false
 
 
-# Backup/Restore options
-#
+# == Backup/Restore options
 attribute :lineage, :kind_of => String
 attribute :timestamp_override, :kind_of => String # Restore only 
 
  
-# Primary Backup
-#
-# Scheduled options
+# == Primary backup schedule options
 attribute :cron_backup_minute, :kind_of => String
 attribute :cron_backup_hour, :kind_of => String
 attribute :cron_backup_recipe, :kind_of => String, :default => "block_device::do_backup"
-# Rotation options
+
+
+# == Rotation options
 attribute :max_snapshots, :kind_of => String
 attribute :keep_daily, :kind_of => String
-attribute :keep_weekly, :kind_of => String
+sattribute :keep_weekly, :kind_of => String
 attribute :keep_monthly, :kind_of => String
 attribute :keep_yearly, :kind_of => String
 attribute :force, :kind_of => [TrueClass, FalseClass], :default => false # Used by backup_lock_take action
-# Volume block devices only
+
+
+# == Options for volume block devices
 attribute :volume_size, :kind_of => String
 attribute :stripe_count, :kind_of => String
 attribute :vg_data_percentage, :kind_of => String
 
-# Callbacks for ROS endpoint validation
+# == Callbacks for ROS endpoint validation
 endpoint_callbacks = {
   "invalid endpoint URL" => Proc.new do |value|
     begin
@@ -53,15 +66,14 @@ endpoint_callbacks = {
   end
 }
 
-# Remote Object Store only
+# == Options for Remote Object Store
 attribute :primary_cloud, :kind_of => String
 attribute :primary_endpoint, :kind_of => String, :callbacks => endpoint_callbacks
 attribute :primary_user, :kind_of => String
 attribute :primary_secret, :kind_of => String
 
 
-# Secondary Backup
-#
+# == Secondary backup options
 attribute :secondary_cloud, :kind_of => String
 attribute :secondary_endpoint, :kind_of => String, :callbacks => endpoint_callbacks
 attribute :secondary_container, :kind_of => String
@@ -69,8 +81,79 @@ attribute :secondary_user, :kind_of => String
 attribute :secondary_secret, :kind_of => String
 
 
-# Cloud specific options
-#
+# == Cloud specific options
 attribute :rackspace_snet, :equal_to => [ true, false ], :default => true
 
 
+# = General Block_device Actions
+#
+# Below are the actions defined by the block_device resource interface.
+#
+
+
+# == Create
+# This utility creates a new block device.
+#
+add_action :create
+
+
+# == Snapshot
+# This action will create a snapshot of a block device previously created
+#
+add_action :snapshot
+
+
+# == Primary Backup
+# Prepare device for primary backup
+#
+add_action :primary_backup
+
+
+# == Primary Restore
+# Prepare device for primary restore
+#
+add_action :primary_restore
+
+
+# == Secondary Backup
+# Prepare device for secondary backup
+#
+add_action :secondary_backup
+
+
+# == Secondary Restore
+# Prepare device for secondary restore
+#
+add_action :secondary_restore
+
+
+# == Reset
+# Unmount and delete the attached block device(s)
+#
+add_action :reset
+
+
+# == Backup Schedule Enable
+# Enable cron-based scheduled backups
+#
+add_action :backup_schedule_enable
+
+
+# == Backup Schedule Disable
+# Disable cron-based scheduled backups
+#
+add_action :backup_schedule_disable
+
+
+# == Backup Lock Take
+# Acquire the backup lock
+#
+add_action :backup_lock_take
+
+
+# == Backup Lock Give
+# Create the backup lock
+#
+add_action :backup_lock_give
+
+actions @action_list


### PR DESCRIPTION
The resources in the block_device cookbook are documented by taking db/resources/default.rb  as an example.
