### PR TITLE
Sprint12 05 a47601 kernel modules

### DIFF
--- a/cookbooks/block_device/recipes/default.rb
+++ b/cookbooks/block_device/recipes/default.rb
@@ -34,6 +34,8 @@ bash "Load kernel modules" do
     modprobe dm_mod
     modprobe dm_snapshot
   EOS
+  # These modules are compiled into the kernel on Ubuntu.
+  not_if { node[:platform] == "ubuntu" }
 end
 
 bash "Load xfs kernel module" do


### PR DESCRIPTION
This fixes: [w4704](https://wush.net/trac/rightscale/ticket/4704).
