### PR TITLE
Sprint12 05 a48020 apache log name convention

### DIFF
--- a/cookbooks/web_apache/templates/ubuntu/apache.conf.erb
+++ b/cookbooks/web_apache/templates/ubuntu/apache.conf.erb
@@ -1,10 +1,10 @@
-# 
+#
 # Cookbook Name:: web_apache
 #
 # Copyright RightScale, Inc. All rights reserved.  All access and use subject to the
 # RightScale Terms of Service available at http://www.rightscale.com/terms.php and,
 # if applicable, other agreements such as a RightScale Master Subscription Agreement.
-# 
+#
 # Managed by RightScale
 # DO NOT EDIT BY HAND
 #

--- a/cookbooks/web_apache/templates/ubuntu/apache.conf.erb
+++ b/cookbooks/web_apache/templates/ubuntu/apache.conf.erb
@@ -1,0 +1,69 @@
+# 
+# Cookbook Name:: web_apache
+#
+# Copyright RightScale, Inc. All rights reserved.  All access and use subject to the
+# RightScale Terms of Service available at http://www.rightscale.com/terms.php and,
+# if applicable, other agreements such as a RightScale Master Subscription Agreement.
+# 
+# Managed by RightScale
+# DO NOT EDIT BY HAND
+#
+
+<VirtualHost *:<%= @params[:vhost_port] %>>
+  ServerName <%= @params[:server_name] %>
+  DocumentRoot <%= @params[:docroot] %>
+  <DirectoryMatch  /\.git/|/\.svn/ >
+    Deny from all
+  </DirectoryMatch>
+
+  <Directory <%= @params[:docroot] %>>
+    Options FollowSymLinks
+    AllowOverride None
+    Order allow,deny
+    Allow from all
+  </Directory>
+
+  RewriteEngine On
+  # Uncomment for rewrite debugging
+  #RewriteLog <%= node[:apache][:log_dir] %>/http_rewrite_log
+  #RewriteLogLevel 9
+
+  # Enable status page for monitoring purposes
+  RewriteCond %{REMOTE_ADDR} ^(127.0.0.1)
+  RewriteRule ^(/server-status) $1 [H=server-status,L]
+
+  # Redirects to a maintenance page if the specified file below exists
+  # ...but it still allows images to be served
+  RewriteCond %{DOCUMENT_ROOT}/system/maintenance.html -f
+  RewriteCond %{SCRIPT_FILENAME} !/system/maintenance.html
+  RewriteCond %{SCRIPT_FILENAME} !^(.+).(gif|png|jpg|css|js|swf)$
+  RewriteRule ^.*$ /system/maintenance.html [L]
+
+  # Next hop is HaProxy
+  RewriteRule ^/(.*)$ http://127.0.0.1:85%{REQUEST_URI} [P,QSA,L]
+
+  # Setup the logs in the appropriate directory
+  CustomLog <%= node[:apache][:log_dir] %>/access.log combined
+  ErrorLog  <%= node[:apache][:log_dir] %>/error.log
+
+  # Serve any existing local files directly (except actionable ones)
+  RewriteCond %{DOCUMENT_ROOT}/%{REQUEST_FILENAME} -f
+  RewriteCond %{REQUEST_FILENAME} !\.php|\.jsp|\.do|\.action$ [NC]
+  RewriteRule ^/(.*)$ /$1 [QSA,L]
+
+  # Special rule to forward "/" directly to haproxy
+  RewriteCond %{DOCUMENT_ROOT}/$ -d
+  RewriteRule ^/(.*)$ http://127.0.0.1:85%{REQUEST_URI} [P,QSA,L]
+
+  RewriteCond %{DOCUMENT_ROOT}/%{REQUEST_FILENAME} -d
+  RewriteRule ^/(.*)$ /$1 [QSA,L]
+
+  LogLevel warn
+
+  # Deflate
+  AddOutputFilterByType DEFLATE text/html text/plain text/xml application/xml application/xhtml+xml text/javascript text/css application/x-javascript
+  BrowserMatch ^Mozilla/4 gzip-only-text/html
+  BrowserMatch ^Mozilla/4\.0[678] no-gzip
+  BrowserMatch \bMSIE !no-gzip !gzip-only-text/html
+
+</VirtualHost>

--- a/cookbooks/web_apache/templates/ubuntu/apache2.conf.erb
+++ b/cookbooks/web_apache/templates/ubuntu/apache2.conf.erb
@@ -1,0 +1,244 @@
+# 
+# Cookbook Name:: web_apache
+#
+# Copyright RightScale, Inc. All rights reserved.  All access and use subject to the
+# RightScale Terms of Service available at http://www.rightscale.com/terms.php and,
+# if applicable, other agreements such as a RightScale Master Subscription Agreement.
+# 
+# Managed by RightScale
+# DO NOT EDIT BY HAND
+#
+
+#
+# Based on the Ubuntu apache2.conf
+
+ServerRoot "<%= node[:apache][:dir] %>"
+
+#
+# The accept serialization lock file MUST BE STORED ON A LOCAL DISK.
+#
+<% if node[:platform] == "debian" || node[:platform] == "ubuntu" -%>
+LockFile /var/lock/apache2/accept.lock
+<% else %>
+LockFile logs/accept.lock
+<% end -%>
+
+#
+# PidFile: The file in which the server should record its process
+# identification number when it starts.
+#
+<% if node[:platform] == "debian" || node[:platform] == "ubuntu" -%>
+PidFile /var/run/apache2.pid
+<% else -%>
+PidFile logs/httpd.pid
+<% end -%>
+
+#
+# Timeout: The number of seconds before receives and sends time out.
+#
+Timeout <%= node[:apache][:timeout] %>
+
+#
+# KeepAlive: Whether or not to allow persistent connections (more than
+# one request per connection). Set to "Off" to deactivate.
+#
+KeepAlive <%= node[:apache][:keepalive] %>
+
+#
+# MaxKeepAliveRequests: The maximum number of requests to allow
+# during a persistent connection. Set to 0 to allow an unlimited amount.
+# We recommend you leave this number high, for maximum performance.
+#
+MaxKeepAliveRequests <%= node[:apache][:keepaliverequests] %>
+
+#
+# KeepAliveTimeout: Number of seconds to wait for the next request from the
+# same client on the same connection.
+#
+KeepAliveTimeout <%= node[:apache][:keepalivetimeout] %>
+
+##
+## Server-Pool Size Regulation (MPM specific)
+## 
+
+# prefork MPM
+# StartServers: number of server processes to start
+# MinSpareServers: minimum number of server processes which are kept spare
+# MaxSpareServers: maximum number of server processes which are kept spare
+# MaxClients: maximum number of server processes allowed to start
+# MaxRequestsPerChild: maximum number of requests a server process serves
+<IfModule mpm_prefork_module>
+    StartServers          <%= node[:apache][:prefork][:startservers] %>
+    MinSpareServers       <%= node[:apache][:prefork][:minspareservers] %>
+    MaxSpareServers       <%= node[:apache][:prefork][:maxspareservers] %>
+    ServerLimit           <%= node[:apache][:prefork][:serverlimit] %>
+    MaxClients            <%= node[:apache][:prefork][:maxclients] %>
+    MaxRequestsPerChild   <%= node[:apache][:prefork][:maxrequestsperchild] %>
+</IfModule>
+
+# worker MPM
+# StartServers: initial number of server processes to start
+# MaxClients: maximum number of simultaneous client connections
+# MinSpareThreads: minimum number of worker threads which are kept spare
+# MaxSpareThreads: maximum number of worker threads which are kept spare
+# ThreadsPerChild: constant number of worker threads in each server process
+# MaxRequestsPerChild: maximum number of requests a server process serves
+<IfModule mpm_worker_module>
+    StartServers          <%= node[:apache][:worker][:startservers] %>
+    MaxClients            <%= node[:apache][:worker][:maxclients] %>
+    MinSpareThreads       <%= node[:apache][:worker][:minsparethreads] %>
+    MaxSpareThreads       <%= node[:apache][:worker][:maxsparethreads] %>
+    ThreadsPerChild       <%= node[:apache][:worker][:threadsperchild] %>
+    MaxRequestsPerChild   <%= node[:apache][:worker][:maxrequestsperchild] %>
+</IfModule>
+
+User <%= node[:apache][:user] %>
+Group <%= node[:apache][:user] %>
+
+#
+# AccessFileName: The name of the file to look for in each directory
+# for additional configuration directives.  See also the AllowOverride
+# directive.
+#
+
+AccessFileName .htaccess
+
+#
+# The following lines prevent .htaccess and .htpasswd files from being 
+# viewed by Web clients. 
+#
+<Files ~ "^\.ht">
+    Order allow,deny
+    Deny from all
+</Files>
+
+#
+# DefaultType is the default MIME type the server will use for a document
+# if it cannot otherwise determine one, such as from filename extensions.
+# If your server contains mostly text or HTML documents, "text/plain" is
+# a good value.  If most of your content is binary, such as applications
+# or images, you may want to use "application/octet-stream" instead to
+# keep browsers from trying to display binary files as though they are
+# text.
+#
+DefaultType text/plain
+
+
+#
+# HostnameLookups: Log the names of clients or just their IP addresses
+# e.g., www.apache.org (on) or 204.62.129.132 (off).
+# The default is off because it'd be overall better for the net if people
+# had to knowingly turn this feature on, since enabling it means that
+# each client request will result in AT LEAST one lookup request to the
+# nameserver.
+#
+HostnameLookups Off
+
+# ErrorLog: The location of the error log file.
+# If you do not specify an ErrorLog directive within a <VirtualHost>
+# container, error messages relating to that virtual host will be
+# logged here.  If you *do* define an error logfile for a <VirtualHost>
+# container, that host's errors will be logged there and not here.
+#
+ErrorLog <%= node[:apache][:log_dir] %>/error.log 
+
+#
+# LogLevel: Control the number of messages logged to the error_log.
+# Possible values include: debug, info, notice, warn, error, crit,
+# alert, emerg.
+#
+LogLevel warn
+
+# Include module configuration:
+Include <%= node[:apache][:dir] %>/mods-enabled/*.load
+Include <%= node[:apache][:dir] %>/mods-enabled/*.conf
+
+# Include ports listing
+Include <%= node[:apache][:dir] %>/ports.conf
+
+#
+# The following directives define some format nicknames for use with
+# a CustomLog directive (see below).
+#
+LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
+LogFormat "%h %l %u %t \"%r\" %>s %b" common
+LogFormat "%{Referer}i -> %U" referer
+LogFormat "%{User-agent}i" agent
+
+#
+# ExtendedStatus controls whether Apache will generate "full" status
+# information (ExtendedStatus On) or just basic information (ExtendedStatus
+# Off) when the "server-status" handler is called. The default is Off.
+#
+ExtendedStatus <%= node[:apache][:extended_status] %>
+
+#
+# Customizable error responses come in three flavors:
+# 1) plain text 2) local redirects 3) external redirects
+#
+# Some examples:
+#ErrorDocument 500 "The server made a boo boo."
+#ErrorDocument 404 /missing.html
+#ErrorDocument 404 "/cgi-bin/missing_handler.pl"
+#ErrorDocument 402 http://www.example.com/subscription_info.html
+#
+
+#
+# Putting this all together, we can internationalize error responses.
+#
+# We use Alias to redirect any /error/HTTP_<error>.html.var response to
+# our collection of by-error message multi-language collections.  We use 
+# includes to substitute the appropriate text.
+#
+# You can modify the messages' appearance without changing any of the
+# default HTTP_<error>.html.var files by adding the line:
+#
+#   Alias /error/include/ "/your/include/path/"
+#
+# which allows you to create your own set of files by starting with the
+# /usr/share/apache2/error/include/ files and copying them to /your/include/path/, 
+# even on a per-VirtualHost basis.  The default include files will display
+# your Apache version number and your ServerAdmin email address regardless
+# of the setting of ServerSignature.
+#
+# The internationalized error documents require mod_alias, mod_include
+# and mod_negotiation.  To activate them, uncomment the following 30 lines.
+
+#    Alias /error/ "/usr/share/apache2/error/"
+#
+#    <Directory "/usr/share/apache2/error">
+#        AllowOverride None
+#        Options IncludesNoExec
+#        AddOutputFilter Includes html
+#        AddHandler type-map var
+#        Order allow,deny
+#        Allow from all
+#        LanguagePriority en cs de es fr it nl sv pt-br ro
+#        ForceLanguagePriority Prefer Fallback
+#    </Directory>
+#
+#    ErrorDocument 400 /error/HTTP_BAD_REQUEST.html.var
+#    ErrorDocument 401 /error/HTTP_UNAUTHORIZED.html.var
+#    ErrorDocument 403 /error/HTTP_FORBIDDEN.html.var
+#    ErrorDocument 404 /error/HTTP_NOT_FOUND.html.var
+#    ErrorDocument 405 /error/HTTP_METHOD_NOT_ALLOWED.html.var
+#    ErrorDocument 408 /error/HTTP_REQUEST_TIME_OUT.html.var
+#    ErrorDocument 410 /error/HTTP_GONE.html.var
+#    ErrorDocument 411 /error/HTTP_LENGTH_REQUIRED.html.var
+#    ErrorDocument 412 /error/HTTP_PRECONDITION_FAILED.html.var
+#    ErrorDocument 413 /error/HTTP_REQUEST_ENTITY_TOO_LARGE.html.var
+#    ErrorDocument 414 /error/HTTP_REQUEST_URI_TOO_LARGE.html.var
+#    ErrorDocument 415 /error/HTTP_UNSUPPORTED_MEDIA_TYPE.html.var
+#    ErrorDocument 500 /error/HTTP_INTERNAL_SERVER_ERROR.html.var
+#    ErrorDocument 501 /error/HTTP_NOT_IMPLEMENTED.html.var
+#    ErrorDocument 502 /error/HTTP_BAD_GATEWAY.html.var
+#    ErrorDocument 503 /error/HTTP_SERVICE_UNAVAILABLE.html.var
+#    ErrorDocument 506 /error/HTTP_VARIANT_ALSO_VARIES.html.var
+
+
+
+# Include generic snippets of statements
+Include <%= node[:apache][:dir] %>/conf.d/
+
+# Include the virtual host configurations:
+Include <%= node[:apache][:dir] %>/sites-enabled/

--- a/cookbooks/web_apache/templates/ubuntu/apache2.conf.erb
+++ b/cookbooks/web_apache/templates/ubuntu/apache2.conf.erb
@@ -1,10 +1,10 @@
-# 
+#
 # Cookbook Name:: web_apache
 #
 # Copyright RightScale, Inc. All rights reserved.  All access and use subject to the
 # RightScale Terms of Service available at http://www.rightscale.com/terms.php and,
 # if applicable, other agreements such as a RightScale Master Subscription Agreement.
-# 
+#
 # Managed by RightScale
 # DO NOT EDIT BY HAND
 #
@@ -59,7 +59,7 @@ KeepAliveTimeout <%= node[:apache][:keepalivetimeout] %>
 
 ##
 ## Server-Pool Size Regulation (MPM specific)
-## 
+##
 
 # prefork MPM
 # StartServers: number of server processes to start
@@ -104,8 +104,8 @@ Group <%= node[:apache][:user] %>
 AccessFileName .htaccess
 
 #
-# The following lines prevent .htaccess and .htpasswd files from being 
-# viewed by Web clients. 
+# The following lines prevent .htaccess and .htpasswd files from being
+# viewed by Web clients.
 #
 <Files ~ "^\.ht">
     Order allow,deny
@@ -140,7 +140,7 @@ HostnameLookups Off
 # logged here.  If you *do* define an error logfile for a <VirtualHost>
 # container, that host's errors will be logged there and not here.
 #
-ErrorLog <%= node[:apache][:log_dir] %>/error.log 
+ErrorLog <%= node[:apache][:log_dir] %>/error.log
 
 #
 # LogLevel: Control the number of messages logged to the error_log.
@@ -187,7 +187,7 @@ ExtendedStatus <%= node[:apache][:extended_status] %>
 # Putting this all together, we can internationalize error responses.
 #
 # We use Alias to redirect any /error/HTTP_<error>.html.var response to
-# our collection of by-error message multi-language collections.  We use 
+# our collection of by-error message multi-language collections.  We use
 # includes to substitute the appropriate text.
 #
 # You can modify the messages' appearance without changing any of the
@@ -196,7 +196,7 @@ ExtendedStatus <%= node[:apache][:extended_status] %>
 #   Alias /error/include/ "/your/include/path/"
 #
 # which allows you to create your own set of files by starting with the
-# /usr/share/apache2/error/include/ files and copying them to /your/include/path/, 
+# /usr/share/apache2/error/include/ files and copying them to /your/include/path/,
 # even on a per-VirtualHost basis.  The default include files will display
 # your Apache version number and your ServerAdmin email address regardless
 # of the setting of ServerSignature.

--- a/cookbooks/web_apache/templates/ubuntu/apache_ssl_vhost.erb
+++ b/cookbooks/web_apache/templates/ubuntu/apache_ssl_vhost.erb
@@ -1,10 +1,10 @@
-# 
+#
 # Cookbook Name:: web_apache
 #
 # Copyright RightScale, Inc. All rights reserved.  All access and use subject to the
 # RightScale Terms of Service available at http://www.rightscale.com/terms.php and,
 # if applicable, other agreements such as a RightScale Master Subscription Agreement.
-# 
+#
 # Managed by RightScale
 # DO NOT EDIT BY HAND
 #
@@ -79,7 +79,7 @@
   BrowserMatch ^Mozilla/4\.0[678] no-gzip
   BrowserMatch \bMSIE !no-gzip !gzip-only-text/html
 
-  SetEnvIf User-Agent ".*MSIE.*" nokeepalive ssl-unclean-shutdown downgrade-1.0 
+  SetEnvIf User-Agent ".*MSIE.*" nokeepalive ssl-unclean-shutdown downgrade-1.0
 
   # Proxy the rest to the load balancer
   RewriteRule ^/(.*)$ http://127.0.0.1:85%{REQUEST_URI} [P,QSA,L]

--- a/cookbooks/web_apache/templates/ubuntu/apache_ssl_vhost.erb
+++ b/cookbooks/web_apache/templates/ubuntu/apache_ssl_vhost.erb
@@ -1,0 +1,87 @@
+# 
+# Cookbook Name:: web_apache
+#
+# Copyright RightScale, Inc. All rights reserved.  All access and use subject to the
+# RightScale Terms of Service available at http://www.rightscale.com/terms.php and,
+# if applicable, other agreements such as a RightScale Master Subscription Agreement.
+# 
+# Managed by RightScale
+# DO NOT EDIT BY HAND
+#
+
+<VirtualHost *:<%= @params[:vhost_port] %>>
+  ServerName <%= @params[:server_name] %>
+  DocumentRoot <%= @params[:docroot] %>
+  <DirectoryMatch  /\.git/|/\.svn/ >
+    Deny from all
+  </DirectoryMatch>
+
+  <Directory <%= @params[:docroot] %>>
+    Options FollowSymLinks
+    AllowOverride None
+    Order allow,deny
+    Allow from all
+  </Directory>
+
+  RewriteEngine On
+  # Uncomment for rewrite debugging
+  #RewriteLog <%= node[:apache][:log_dir] %>/http_rewrite.log
+  #RewriteLogLevel 9
+
+  # Enable status page for monitoring purposes
+  RewriteCond %{REMOTE_ADDR} ^(127.0.0.1)
+  RewriteRule ^(/server-status) $1 [H=server-status,L]
+
+  # Redirects to a maintenance page if the specified file below exists
+  # ...but it still allows images to be served
+  RewriteCond %{DOCUMENT_ROOT}/system/maintenance.html -f
+  RewriteCond %{SCRIPT_FILENAME} !/system/maintenance.html
+  RewriteCond %{SCRIPT_FILENAME} !^(.+).(gif|png|jpg|css|js|swf)$
+  RewriteRule ^.*$ /system/maintenance.html [L]
+
+  # Next hop is HaProxy
+  RewriteRule ^/(.*)$ http://127.0.0.1:85%{REQUEST_URI} [P,QSA,L]
+
+  # Setup the logs in the appropriate directory
+  CustomLog <%= node[:apache][:log_dir] %>/access.log combined
+  ErrorLog  <%= node[:apache][:log_dir] %>/error.log
+
+  # Serve any existing local files directly (except actionable ones)
+  RewriteCond %{DOCUMENT_ROOT}/%{REQUEST_FILENAME} -f
+  RewriteCond %{REQUEST_FILENAME} !\.php|\.jsp|\.do|\.action$ [NC]
+  RewriteRule ^/(.*)$ /$1 [QSA,L]
+
+  # Special rule to forward "/" directly to haproxy
+  RewriteCond %{DOCUMENT_ROOT}/$ -d
+  RewriteRule ^/(.*)$ http://127.0.0.1:85%{REQUEST_URI} [P,QSA,L]
+
+  RewriteCond %{DOCUMENT_ROOT}/%{REQUEST_FILENAME} -d
+  RewriteRule ^/(.*)$ /$1 [QSA,L]
+
+  LogLevel warn
+
+  # SSL-specific additions
+  SSLEngine on
+  SSLProtocol all -SSLv2
+  SSLCipherSuite ALL:!ADH:!EXPORT:!SSLv2:RC4+RSA:+HIGH:+MEDIUM:+LOW
+
+  RequestHeader set X_FORWARDED_PROTO 'https'
+
+  SSLCertificateFile <%= @params[:ssl_certificate_file] %>
+  SSLCertificateKeyFile <%= @params[:ssl_key_file] %>
+  <% if @params[:ssl_certificate_chain_file] %>
+    <%= "SSLCertificateChainFile #{@params[:ssl_certificate_chain_file]}" %>
+  <% end %>
+
+  # Deflate
+  AddOutputFilterByType DEFLATE text/html text/plain text/xml application/xml application/xhtml+xml text/javascript text/css application/x-javascript
+  BrowserMatch ^Mozilla/4 gzip-only-text/html
+  BrowserMatch ^Mozilla/4\.0[678] no-gzip
+  BrowserMatch \bMSIE !no-gzip !gzip-only-text/html
+
+  SetEnvIf User-Agent ".*MSIE.*" nokeepalive ssl-unclean-shutdown downgrade-1.0 
+
+  # Proxy the rest to the load balancer
+  RewriteRule ^/(.*)$ http://127.0.0.1:85%{REQUEST_URI} [P,QSA,L]
+
+</VirtualHost>

--- a/cookbooks/web_apache/templates/ubuntu/app_server.erb
+++ b/cookbooks/web_apache/templates/ubuntu/app_server.erb
@@ -1,0 +1,54 @@
+# 
+# Cookbook Name:: web_apache
+#
+# Copyright RightScale, Inc. All rights reserved.  All access and use subject to the
+# RightScale Terms of Service available at http://www.rightscale.com/terms.php and,
+# if applicable, other agreements such as a RightScale Master Subscription Agreement.
+# 
+# Managed by RightScale
+# DO NOT EDIT BY HAND
+#
+
+<VirtualHost *:<%= @params[:vhost_port] %>>
+  ServerName <%= @params[:server_name] %>
+  DocumentRoot <%= @params[:docroot] %>
+  <DirectoryMatch  /\.git/|/\.svn/ >
+    Deny from all
+  </DirectoryMatch>
+
+  <Directory <%= @params[:docroot] %>>
+    Options FollowSymLinks
+    AllowOverride None
+    Order allow,deny
+    Allow from all
+  </Directory>
+
+  RewriteEngine On
+  # Uncomment for rewrite debugging
+  #RewriteLog <%= node[:apache][:log_dir] %>/http_rewrite.log
+  #RewriteLogLevel 9
+
+  # Enable status page for monitoring purposes
+  RewriteCond %{REMOTE_ADDR} ^(127.0.0.1)
+  RewriteRule ^(/server-status) $1 [H=server-status,L]
+
+  # Redirects to a maintenance page if the specified file below exists
+  # ...but it still allows images to be served
+  RewriteCond %{DOCUMENT_ROOT}/system/maintenance.html -f
+  RewriteCond %{SCRIPT_FILENAME} !/system/maintenance.html
+  RewriteCond %{SCRIPT_FILENAME} !^(.+).(gif|png|jpg|css|js|swf)$
+  RewriteRule ^.*$ /system/maintenance.html [L]
+
+  # Setup the logs in the appropriate directory
+  CustomLog <%= node[:apache][:log_dir] %>/access.log combined
+  ErrorLog  <%= node[:apache][:log_dir] %>/error.log
+
+  LogLevel warn
+
+  # Deflate
+  AddOutputFilterByType DEFLATE text/html text/plain text/xml application/xml application/xhtml+xml text/javascript text/css application/x-javascript
+  BrowserMatch ^Mozilla/4 gzip-only-text/html
+  BrowserMatch ^Mozilla/4\.0[678] no-gzip
+  BrowserMatch \bMSIE !no-gzip !gzip-only-text/html
+
+</VirtualHost>

--- a/cookbooks/web_apache/templates/ubuntu/app_server.erb
+++ b/cookbooks/web_apache/templates/ubuntu/app_server.erb
@@ -1,10 +1,10 @@
-# 
+#
 # Cookbook Name:: web_apache
 #
 # Copyright RightScale, Inc. All rights reserved.  All access and use subject to the
 # RightScale Terms of Service available at http://www.rightscale.com/terms.php and,
 # if applicable, other agreements such as a RightScale Master Subscription Agreement.
-# 
+#
 # Managed by RightScale
 # DO NOT EDIT BY HAND
 #


### PR DESCRIPTION
Ubuntu and Centos uses different naming conventions for log files.  These changes were made to match those defaults.
