### PR TITLE
Syntax fix for value_for_platform on db_mysql

### DIFF
--- a/cookbooks/db_mysql/recipes/default_5_1.rb
+++ b/cookbooks/db_mysql/recipes/default_5_1.rb
@@ -18,7 +18,7 @@ node[:db_mysql][:version] = version
 
 node[:db][:socket] = value_for_platform(
   "ubuntu"  => {"default" => "/var/run/mysqld/mysqld.sock"},
-  "default" => {"default" => "/var/lib/mysql/mysql.sock"}
+  "default" => "/var/lib/mysql/mysql.sock"
 )
 
 node[:db_mysql][:service_name] = value_for_platform(

--- a/cookbooks/db_mysql/recipes/default_5_1.rb
+++ b/cookbooks/db_mysql/recipes/default_5_1.rb
@@ -17,8 +17,8 @@ log "  Setting DB MySQL version to #{version}"
 node[:db_mysql][:version] = version
 
 node[:db][:socket] = value_for_platform(
-  "ubuntu"  => "/var/run/mysqld/mysqld.sock",
-  "default" => "/var/lib/mysql/mysql.sock"
+  "ubuntu"  => {"default" => "/var/run/mysqld/mysqld.sock"},
+  "default" => {"default" => "/var/lib/mysql/mysql.sock"}
 )
 
 node[:db_mysql][:service_name] = value_for_platform(

--- a/cookbooks/db_mysql/recipes/default_5_5.rb
+++ b/cookbooks/db_mysql/recipes/default_5_5.rb
@@ -17,7 +17,7 @@ platform = node[:platform]
 #
 node[:db][:socket] = value_for_platform(
   "ubuntu"  => {"default" => "/var/run/mysqld/mysqld.sock"},
-  "default" => {"default" => "/var/lib/mysql/mysql.sock"}
+  "default" => "/var/lib/mysql/mysql.sock"
 )
 
 node[:db_mysql][:service_name] = "mysqld"

--- a/cookbooks/db_mysql/recipes/default_5_5.rb
+++ b/cookbooks/db_mysql/recipes/default_5_5.rb
@@ -16,8 +16,8 @@ platform = node[:platform]
 # Set MySQL 5.5 specific node variables in this recipe.
 #
 node[:db][:socket] = value_for_platform(
-  "ubuntu"  => "/var/run/mysqld/mysqld.sock",
-  "default" => "/var/lib/mysql/mysql.sock"
+  "ubuntu"  => {"default" => "/var/run/mysqld/mysqld.sock"},
+  "default" => {"default" => "/var/lib/mysql/mysql.sock"}
 )
 
 node[:db_mysql][:service_name] = "mysqld"


### PR DESCRIPTION
Chef doesn't like it when you don't specify a version, or a default.
