### PR TITLE
collectd pinned version should be 4.10.1-2.1ubuntu7 on 12.04

### DIFF
--- a/cookbooks/rightscale/attributes/monitoring.rb
+++ b/cookbooks/rightscale/attributes/monitoring.rb
@@ -15,7 +15,7 @@ when "ubuntu"
   when /^12\..+/
     set_unless[:rightscale][:collectd_packages_version] = "latest"
   else
-    set_unless[:rightscale][:collectd_packages_version] = "4.10.1-2"
+    set_unless[:rightscale][:collectd_packages_version] = "4.10.1-2.1ubuntu7"
   end
   set_unless[:rightscale][:collectd_config] = "/etc/collectd/collectd.conf"
   set_unless[:rightscale][:collectd_plugin_dir] = "/etc/collectd/conf"


### PR DESCRIPTION
chef attributes for 12
https://github.com/rightscale/rightscale_cookbooks/blob/master/cookbooks/rightscale/attributes/monitoring.rb

 when /^12..+/
    set_unless[:rightscale][:collectd_packages_version] = "latest"
  else
    set_unless[:rightscale][:collectd_packages_version] = "4.10.1-2"

should be

 when /^12..+/
    set_unless[:rightscale][:collectd_packages_version] = "latest"
  else
    set_unless[:rightscale][:collectd_packages_version] = "4.10.1-2.1ubuntu7"

root@ip-10-68-22-119:~# apt-get install collectd=4.10.1-2
Reading package lists... Done
Building dependency tree  
Reading state information... Done
E: Version '4.10.1-2' for 'collectd' was not found

[8/23/12 4:25:23 PM] Edwin: root@ip-10-68-22-119:~# apt-get install collectd=4.10.1-2.1ubuntu7
Reading package lists... Done
Building dependency tree  
Reading state information... Done
Recommended packages:
  libesmtp6 libmemcached6 libnotify4 libopenipmi0 liboping0 libperl5.14 libpq5 libsnmp15 libtokyotyrant3 libupsclient1 libvirt0 libyajl1
The following NEW packages will be installed:
  collectd

Thanks.
