### PR TITLE
Remove unnecessary/misleading exception handling for rightscale_tools in block_device lib

### DIFF
--- a/cookbooks/block_device/libraries/block_device.rb
+++ b/cookbooks/block_device/libraries/block_device.rb
@@ -5,12 +5,7 @@
 # RightScale Terms of Service available at http://www.rightscale.com/terms.php and,
 # if applicable, other agreements such as a RightScale Master Subscription Agreement.
 
-begin
-  require 'rightscale_tools'
-rescue LoadError
-  Chef::Log.warn("Missing gem 'rightscale_tools'")
-end
-
+require 'rightscale_tools'
 
 module RightScale
   module BlockDeviceHelper

--- a/cookbooks/block_device/recipes/default.rb
+++ b/cookbooks/block_device/recipes/default.rb
@@ -7,6 +7,8 @@
 
 rightscale_marker :begin
 
+include_recipe "rightscale::install_tools"
+
 class Chef::Recipe
   include RightScale::BlockDeviceHelper
 end


### PR DESCRIPTION
Cookbooks depending on rightscale_tools should simply depend on the rightscale cookbook in metadata and include the rightscale::install_tools recipe to install the gem packages in the compile phase, ideally via the chef_gem resource.
