### PR TITLE
CONTRIB: Apply the environment on the first chef-client run; otherwise, the envir...

### DIFF
--- a/cookbooks/chef/recipes/install_client.rb
+++ b/cookbooks/chef/recipes/install_client.rb
@@ -71,7 +71,7 @@ node[:chef][:client][:current_roles] = node[:chef][:client][:roles]
 log "  Chef Client configuration is completed."
 
 # Sets command extensions and attributes.
-extension = "-j #{node[:chef][:client][:config_dir]}/runlist.json"
+extension = "-j #{node[:chef][:client][:config_dir]}/runlist.json -E #{node[:chef][:client][:environment]}"
 extension << " -o #{node[:chef][:client][:json_attributes]}" \
   unless node[:chef][:client][:json_attributes].empty?
 


### PR DESCRIPTION
Use the -E [environment] on the first run of the chef-client, otherwise, the environment is not applied to the node, and the provisioning can fail, depending on what the settings for the environment are.
