### PR TITLE
Actually do security updates for ubuntu platform; assume y with apt-get ...

### DIFF
--- a/cookbooks/rightscale/recipes/do_security_updates.rb
+++ b/cookbooks/rightscale/recipes/do_security_updates.rb
@@ -18,7 +18,8 @@ if "#{node[:rightscale][:security_updates]}" == "enable"
         # Make sure we DON'T check the output of this, as apt-get update
         # may return a non-zero error code when one server is down but all
         # the others are up, and a partial update was successful!
-        apt-get update || true
+        apt-get -y update || true
+        apt-get -y upgrade
       EOH
     end
   end


### PR DESCRIPTION
Currently do_security_updates recipe does not actually install any new package versions. Use upgrade with apt-get and also assume y with each apt-get command.
