### PR TITLE
Always send valid node name to the chef server

### DIFF
--- a/cookbooks/chef/README.md
+++ b/cookbooks/chef/README.md
@@ -58,6 +58,9 @@ These are the settings used in recipes and templates. Default values are noted.
   located on the Server and in the Client configuration file must match.
 * `node[:chef][:client][:node_name]`-
   The node's name to register on the Chef Server.
+  Valid node name must contain only alpabetic, numeric and `.-_:` characters.
+  The other characters will be removed. If nothing is specified, the instance
+  FQDN will be used. Example: chef-client-host1
 * `node[:chef][:client][:roles]`-
   Comma separated list of roles which will be applied to this instance. Roles
   should be defined on the Chef Server else recipe will fail.

--- a/cookbooks/chef/metadata.json
+++ b/cookbooks/chef/metadata.json
@@ -79,7 +79,7 @@
     },
     "chef/client/node_name": {
       "display_name": "Chef Client Node Name",
-      "description": "Name which will be used to authenticate the Chef Client on the remote Chef Server. If nothing is specified, the instance FQDN will be used. Example: chef-client-host1",
+      "description": "Name which will be used to authenticate the Chef Client on the remote Chef Server. If nothing is specified, the instance FQDN will be used. Valid node name must contain only alpabetic, numeric and .-_: characters. Example: chef-client-host1. The other characters in the node name will be removed.",
       "required": "optional",
       "recipes": [
         "chef::install_client"

--- a/cookbooks/chef/metadata.rb
+++ b/cookbooks/chef/metadata.rb
@@ -63,7 +63,9 @@ attribute "chef/client/node_name",
   :description =>
     "Name which will be used to authenticate the Chef Client on the remote" +
     " Chef Server. If nothing is specified, the instance FQDN will be used." +
-    " Example: chef-client-host1",
+    " Valid node name must contain only alpabetic, numeric and .-_: characters." +
+    " Example: chef-client-host1." +
+    " The other characters in the node name will be removed.",
   :required => "optional",
   :recipes => ["chef::install_client"]
 

--- a/cookbooks/chef/recipes/install_client.rb
+++ b/cookbooks/chef/recipes/install_client.rb
@@ -27,6 +27,10 @@ log "  Chef Client version #{node[:chef][:client][:version]} installation is" +
 # Creates the Chef Client configuration directory.
 directory node[:chef][:client][:config_dir]
 
+name_from_input = node[:chef][:client][:node_name]
+# For node name constraints see http://wiki.opscode.com/display/chef10/Nodes .
+valid_node_name = (name_from_input || node[:fqdn]).gsub(/[^\-[:alnum:]_:.]+/, '')
+
 # Creates the Chef Client configuration file.
 template "#{node[:chef][:client][:config_dir]}/client.rb" do
   source "client.rb.erb"
@@ -36,7 +40,7 @@ template "#{node[:chef][:client][:config_dir]}/client.rb" do
   variables(
     :server_url => node[:chef][:client][:server_url],
     :validation_name => node[:chef][:client][:validation_name],
-    :node_name => node[:chef][:client][:node_name],
+    :node_name => valid_node_name,
     :log_level => node[:chef][:client][:log_level],
     :log_location => node[:chef][:client][:log_location]
   )
@@ -67,7 +71,7 @@ template "#{node[:chef][:client][:config_dir]}/runlist.json" do
   mode "0440"
   backup false
   variables(
-    :node_name => node[:chef][:client][:node_name],
+    :node_name => valid_node_name,
     :environment => node[:chef][:client][:environment],
     :company => node[:chef][:client][:company],
     :roles => node[:chef][:client][:roles]


### PR DESCRIPTION
Without node name validation it is possible to enter incorrect `node_name` input and get boot script failure. In this PR I validate name against official Chef regex for node names. I also remove invalid characters - this feature helped me to create Server Array in the RS with the name like 'web.node.auto' and when I set `node_name` input to `Env: RS_SERVER_NAME` I get correctly formatted node names on Chef Server with auto-increment like 'web.node.auto1', 'web.node.auto2' - names like these are way better than FQDN. Without this fix I was receiving names 'web.node.auto #1' which are incorrect node names.
