### PR TITLE
change variable used for docroot

### DIFF
--- a/cookbooks/app/metadata.rb
+++ b/cookbooks/app/metadata.rb
@@ -5,7 +5,7 @@ description      "RightScale application server management cookbook. This" +
                  " cookbook contains recipes that are generally applicable to" +
                  " all applications."
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "13.5.0"
+version          "13.6.0"
 
 supports "centos"
 supports "redhat"
@@ -20,6 +20,7 @@ depends "app_tomcat"
 depends "db"
 depends "app_django"
 depends "app_jboss"
+depends "app_php54"
 
 recipe "app::install_server",
   "Adds the appserver:active=true, appserver:listen_ip=<ip> and" +

--- a/cookbooks/app_php/providers/default.rb
+++ b/cookbooks/app_php/providers/default.rb
@@ -78,7 +78,7 @@ end
 # Sets up apache PHP virtual host
 action :setup_vhost do
 
-  project_root = new_resource.destination
+  project_root = new_resource.root
   php_port = new_resource.port
 
   # Disable default vhost


### PR DESCRIPTION
This fixes a bug where I was not able to change the DocumentRoot for the Apache vhost configuration.  The recipe calling provider this sets the root variable not the destination variable.  
