### PR TITLE
/root/.chef/knife.rb requried by knife

### DIFF
--- a/cookbooks/chef/metadata.rb
+++ b/cookbooks/chef/metadata.rb
@@ -37,7 +37,7 @@ attribute "chef/client/server_url",
     " https://api.opscode.com/organizations/ORGNAME." +
     " Example: http://example.com:4000/chef",
   :required => "required",
-  :recipes => ["chef::install_client"]
+  :recipes => ["chef::install_client", "chef::do_unregister_request"]
 
 attribute "chef/client/validator_pem",
   :display_name => "Private Key to Register the Chef Client with the Chef" +

--- a/cookbooks/chef/recipes/install_client.rb
+++ b/cookbooks/chef/recipes/install_client.rb
@@ -51,7 +51,7 @@ end
 
 # required by knife
 link "/root/.chef/knife.rb" do
-  to "/etc/chef/client.rb"
+  to "#{node[:chef][:client][:config_dir]}/client.rb"
 end
 
 # Creates the private key to register the Chef Client with the Chef Server.

--- a/cookbooks/chef/recipes/install_client.rb
+++ b/cookbooks/chef/recipes/install_client.rb
@@ -42,6 +42,18 @@ template "#{node[:chef][:client][:config_dir]}/client.rb" do
   )
 end
 
+directory "/root/.chef" do
+  owner "root"
+  group "root"
+  mode 00600
+  action :create
+end
+
+# required by knife
+link "/root/.chef/knife.rb" do
+  to "/etc/chef/client.rb"
+end
+
 # Creates the private key to register the Chef Client with the Chef Server.
 template "#{node[:chef][:client][:config_dir]}/validation.pem" do
   source "validation_key.erb"


### PR DESCRIPTION
chef 11 expects knife.rb in /root/.chef
Otherwise, the 'chef::do_unregister_request' decommissioning recipe fails
